### PR TITLE
Added filter property on PineconeStore to enable metadata filtering

### DIFF
--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -12,7 +12,7 @@ export interface PineconeLibArgs {
   pineconeIndex: VectorOperationsApi;
   textKey?: string;
   namespace?: string;
-  filter?: any;
+  filter?: PineconeMetadata;
 }
 
 export class PineconeStore extends VectorStore {
@@ -22,7 +22,7 @@ export class PineconeStore extends VectorStore {
 
   pineconeIndex: VectorOperationsApi;
 
-  filter?: any;
+  filter?: PineconeMetadata;
 
   constructor(embeddings: Embeddings, args: PineconeLibArgs) {
     super(embeddings, args);


### PR DESCRIPTION
I simply added the filter property to the PineconeStore to enable metadata filtering. I set `filter?: PineconeMetadata;`, using the existing PineconeMetadata type.

My first open-source contribution, so please let me know if I am missing anything.